### PR TITLE
Fix cursor color when revert to non-dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -60,7 +60,7 @@
 }
 
 /* Cursor */
-.kix-cursor-caret {
+.darkdocs .kix-cursor-caret {
   border-color: #fff !important;
 }
 


### PR DESCRIPTION
Noticed the cursor color didn't revert to black when switching to non-dark mode